### PR TITLE
/users/{userId}/follow、/users/{userId}/unfollowの実装

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -5,13 +5,17 @@ namespace App\Http\Controllers;
 use App\Models\User;
 use Illuminate\Http\Request;
 use App\UseCases\User\ShowAction;
+use App\UseCases\User\FollowAction;
+use App\UseCases\User\UnFollowAction;
 use App\UseCases\User\UpdateAction;
 use App\Http\Resources\UserResource;
 use App\UseCases\User\DestroyAction;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\User\ShowRequest;
+use App\Http\Requests\User\FollowRequest;
 use App\Http\Requests\User\UpdateRequest;
 use App\Http\Requests\User\DestroyRequest;
+use App\Http\Requests\User\UnfollowRequest;
 
 
 class UserController extends Controller
@@ -44,6 +48,18 @@ class UserController extends Controller
 
         $result = $destroyAction($userId);
 
+        return new UserResource($result);
+    }
+
+    public function follow(FollowRequest $request, FollowAction $followAction, $userId)
+    {
+        $result = $followAction($request, $userId);
+        return new UserResource($result);
+    }
+
+    public function unfollow(UnfollowRequest $request, UnfollowAction $unfollowAction, $userId)
+    {
+        $result = $unfollowAction($request, $userId);
         return new UserResource($result);
     }
 }

--- a/app/Http/Requests/User/FollowRequest.php
+++ b/app/Http/Requests/User/FollowRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FollowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            //
+        ];
+    }
+}
+
+// めも
+// フォローする人・フォローされる人は重複してはならないのでユニークでなければならない。マイグレーションで対応済み。

--- a/app/Http/Requests/User/UnfollowRequest.php
+++ b/app/Http/Requests/User/UnfollowRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UnfollowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -16,19 +16,21 @@ class UserResource extends JsonResource
     {
         // return parent::toArray($request);
         return [
-            'id' => $this->resource->id,
-            'name' => $this->resource->name,
-            'introduction' => $this->resource->introduction,
-            'iconAttachment' => [
-                [
+            [
+                'id' => $this->resource->id,
+                'name' => $this->resource->name,
+                'introduction' => $this->resource->introduction,
+                'iconAttachment' => [
                     'id' => $this->resource->attachment_id,
                     'type' => 'string',
                     'url' => 'string',
                     'preview_url' => 'string',
                     'description' => 'string',
-                ]
-            ],
-            'deletedAt' => $this->resource->deletedAt, 
+                ],
+                'follow_count' => $this->resource->follow_count,
+                'follower_count' => $this->resource->follower_count,
+                'deletedAt' => $this->resource->deletedAt, 
+            ]
         ];
     }
 }

--- a/app/UseCases/User/FollowAction.php
+++ b/app/UseCases/User/FollowAction.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\UseCases\User;
+
+use App\Models\User;
+use App\Models\Follow;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Http\Resources\UserResource;
+
+class FollowAction
+{
+    public function __invoke(Request $request, $userId)
+    {
+        $followUserId = Auth::id();
+        // 自分自身をフォローしようとしていないかをチェック
+        if ($followUserId !== (int)$userId) {
+            // フォローを作成
+            $follow = Follow::create([
+                'following_user_id' => $followUserId,
+                'followed_user_id' => $userId,
+            ]);
+            // フォロー数を取得
+            $followCount = Follow::where('following_user_id', $userId)->count();
+            // フォロワー数を取得
+            $followerCount = Follow::where('followed_user_id', $userId)->count();
+
+            // フォローを作成したユーザーを取得
+            $followedUser = User::find($userId);
+            // フォロー数とフォロワー数をユーザーモデルにセット
+            $followedUser->follow_count = $followCount;
+            $followedUser->follower_count = $followerCount;
+
+            // UserResourceに渡すデータに id、フォロー数、フォロワー数を含める
+            return new UserResource($followedUser);
+        }
+    }
+}
+
+
+// めも
+// 自分がフォローすると、自分のフォロー数が増えて、相手のフォロワー数が増える
+// 相手からフォローされると、相手のフォロー数が増えて、自分のフォロワー数が増える
+
+// mysql> select * from follows;
+// +----+-------------------+------------------+------------+------------+
+// | id | following_user_id | followed_user_id | created_at | updated_at |
+// +----+-------------------+------------------+------------+------------+
+// |  1 |                 3 |                4 | NULL       | NULL       |
+// |  2 |                 1 |                3 | NULL       | NULL       |
+// +----+-------------------+------------------+------------+------------+
+// 2 rows in set (0.00 sec)
+
+
+// 1のユーザーfollowing_user_idは、3のユーザーfollowed_user_idをフォローしているので、フォロー数は1
+// 1のユーザーfollowed_user_idは、誰からもフォローされていないので、フォロワー数は0
+
+// 3のユーザーfollowing_user_idは、4のユーザーfollowed_user_idをフォローしているので、フォロー数は1
+// 3のユーザーfollowed_user_idは、1のユーザーfollowing_user_idにフォローされているので、フォロワー数は1

--- a/app/UseCases/User/UnfollowAction.php
+++ b/app/UseCases/User/UnfollowAction.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\UseCases\User;
+
+use App\Models\User;
+use App\Models\Follow;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Http\Resources\UserResource;
+
+class UnfollowAction
+{
+    public function __invoke(Request $request, $userId)
+    {
+        $followUserId = Auth::id();
+        // 自分自身をフォローしようとしていないかをチェック
+        if ($followUserId !== (int)$userId) {
+            // フォローを作成
+            $follow = Follow::where([
+                'following_user_id' => $followUserId,
+                'followed_user_id' => $userId,
+            ])->delete();
+        
+            // フォロー数を取得
+            $followCount = Follow::where('following_user_id', $userId)->count();
+
+            // フォロワー数を取得
+            $followerCount = Follow::where('followed_user_id', $userId)->count();
+
+            // フォローを作成したユーザーを取得
+            $followedUser = User::find($userId);
+            // フォロー数とフォロワー数をユーザーモデルにセット
+            $followedUser->follow_count = $followCount;
+            $followedUser->follower_count = $followerCount;
+
+            // UserResourceに渡すデータに id、フォロー数、フォロワー数を含める
+            return new UserResource($followedUser);
+        }
+    }
+}

--- a/database/migrations/2024_03_16_234321_add_unique_constraint_to_follows_table.php
+++ b/database/migrations/2024_03_16_234321_add_unique_constraint_to_follows_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('follows', function (Blueprint $table) {
+            // ユニーク制約を追加する
+            $table->unique(['following_user_id', 'followed_user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('follows', function (Blueprint $table) {
+            // ユニーク制約を削除する
+            $table->dropUnique(['following_user_id', 'followed_user_id']);
+        });
+    }
+};

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -166,7 +166,7 @@ paths:
         - user
       operationId: FollowUser
       parameters:
-        - name: userId
+        - name: userId           # フォローする相手のuserId（followed_user_id）
           in: path
           required: true
           schema:
@@ -188,7 +188,7 @@ paths:
         - user
       operationId: UnfollowUser
       parameters:
-        - name: userId
+        - name: userId           # フォローする相手のuserId（followed_user_id）
           in: path
           required: true
           schema:
@@ -430,9 +430,9 @@ components:
           type: string
         iconAttachment:
           $ref: '#/components/schemas/Attachment'
-        follow_count:
+        follow_count:           # フォロー数（following_user_id）
           type: integer
-        follower_count: 
+        follower_count:           # フォロワー数（followed_user_id）
           type: integer
         deletedAt:
           type: string


### PR DESCRIPTION
実装内容
/users/{userId}/follow
/users/{userId}/unfollow
フォローする・フォロー解除機能、フォロー数・フォロワー数のカウント処理

詳細は以下の通りです。
・openapi.yamlのフォロー機能のAPI定義修正
・「api.php」のルーティング（前回のプルリクで実装済み）
・「UserController.php」に「follow()」メソッド・「unfollow()」メソッドを追加
・「FollowAction.php」「UnfollowAction.php」でフォロー機能を実装
・「FollowRequest.php」「UnFollowRequest.php」でバリデーションルールの定義
・同じuserIdのユーザーを何回もフォローすることができてしまうので、「follows」テーブルの「following_user_id」と「followed_user_id」がユニーク制約がないため、マイグレーションで実行。
・「UserResource.php」にJSON配列のカッコを追加、「follow_count」と「follower_count」を追加

以上です。