### PR TITLE
フォロー機能のポリシー実装

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -53,12 +53,14 @@ class UserController extends Controller
 
     public function follow(FollowRequest $request, FollowAction $followAction, $userId)
     {
+        $this->authorize('follow', [User::class, $userId]);
         $result = $followAction($request, $userId);
         return new UserResource($result);
     }
 
     public function unfollow(UnfollowRequest $request, UnfollowAction $unfollowAction, $userId)
     {
+        $this->authorize('unfollow', [User::class, $userId]);
         $result = $unfollowAction($request, $userId);
         return new UserResource($result);
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -5,13 +5,17 @@ namespace App\Http\Controllers;
 use App\Models\User;
 use Illuminate\Http\Request;
 use App\UseCases\User\ShowAction;
+use App\UseCases\User\FollowAction;
+use App\UseCases\User\UnFollowAction;
 use App\UseCases\User\UpdateAction;
 use App\Http\Resources\UserResource;
 use App\UseCases\User\DestroyAction;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\User\ShowRequest;
+use App\Http\Requests\User\FollowRequest;
 use App\Http\Requests\User\UpdateRequest;
 use App\Http\Requests\User\DestroyRequest;
+use App\Http\Requests\User\UnfollowRequest;
 
 
 class UserController extends Controller
@@ -44,6 +48,18 @@ class UserController extends Controller
 
         $result = $destroyAction($userId);
 
+        return new UserResource($result);
+    }
+
+    public function follow(FollowRequest $request, FollowAction $followAction, $userId)
+    {
+        $result = $followAction($request, $userId);
+        return new UserResource($result);
+    }
+
+    public function unfollow(UnfollowRequest $request, UnfollowAction $unfollowAction, $userId)
+    {
+        $result = $unfollowAction($request, $userId);
         return new UserResource($result);
     }
 }

--- a/app/Http/Requests/User/FollowRequest.php
+++ b/app/Http/Requests/User/FollowRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FollowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            //
+        ];
+    }
+}
+
+// めも
+// フォローする人・フォローされる人は重複してはならないのでユニークでなければならない。マイグレーションで対応済み。

--- a/app/Http/Requests/User/UnfollowRequest.php
+++ b/app/Http/Requests/User/UnfollowRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UnfollowRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -16,19 +16,21 @@ class UserResource extends JsonResource
     {
         // return parent::toArray($request);
         return [
-            'id' => $this->resource->id,
-            'name' => $this->resource->name,
-            'introduction' => $this->resource->introduction,
-            'iconAttachment' => [
-                [
+            [
+                'id' => $this->resource->id,
+                'name' => $this->resource->name,
+                'introduction' => $this->resource->introduction,
+                'iconAttachment' => [
                     'id' => $this->resource->attachment_id,
                     'type' => 'string',
                     'url' => 'string',
                     'preview_url' => 'string',
                     'description' => 'string',
-                ]
-            ],
-            'deletedAt' => $this->resource->deletedAt, 
+                ],
+                'follow_count' => $this->resource->follow_count,
+                'follower_count' => $this->resource->follower_count,
+                'deletedAt' => $this->resource->deletedAt, 
+            ]
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -59,6 +59,18 @@ class User extends Authenticatable
     {
         return $this->hasMany(Follow::class, 'followed_user_id');
     }
+
+    // フォロー数を取得
+    public function followCount($userId)
+    {
+        return Follow::where('following_user_id', $userId)->count();
+    }
+
+    // フォロワー数を取得
+    public function followerCount($userId)
+    {
+        return Follow::where('followed_user_id', $userId)->count();
+    }
 }
 
 // めも

--- a/app/Policies/FollowPolicy.php
+++ b/app/Policies/FollowPolicy.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\Follow;
+use Illuminate\Auth\Access\Response;
+
+class FollowPolicy
+{
+    /**
+     * Create a new policy instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    public function follow(User $user, $userId)
+    {
+        // フォローする相手の$userIdが存在しないかどうかを確認
+        $followUser = User::find($userId);
+
+        if (!$followUser) {
+            // フォローする相手の$userIdが存在しない場合
+            throw new \InvalidArgumentException('対象のユーザーが見つかりません。');
+        }
+
+        // 自分自身をフォローしようとしている場合は認可しない
+        if ($user->id == $userId) {
+            return Response::deny('自分自身をフォローすることはできません。');
+        }
+
+        // すでにフォローしている場合は認可しない
+        $existingFollow = Follow::where('following_user_id', $user->id)
+            ->where('followed_user_id', $userId)
+            ->exists();
+        
+        if ($existingFollow) {
+            return Response::deny('すでにフォローしています。');
+        }
+
+        // その他の場合は認可
+        return Response::allow();
+    }
+
+    public function unfollow(User $user, $userId)
+    {
+        // フォロー解除する相手の$userIdが存在しないかどうかを確認
+        $followUser = User::find($userId);
+
+        if (!$followUser) {
+            // フォロー解除する相手の$userIdが存在しない場合
+            throw new \InvalidArgumentException('対象のユーザーが見つかりません。');
+        }
+
+        // 自分自身をフォロー解除しようとしている場合は認可しない
+        if ($user->id == $userId) {
+            return Response::deny('自分自身をフォロー解除することはできません。');
+        }
+
+        // フォローしていていない場合は認可しない
+        $existingFollowed = Follow::where('following_user_id', $user->id)
+        ->where('followed_user_id', $userId)
+        ->exists();
+    
+        if (!$existingFollowed) {
+            // フォローしていない場合はエラーを返す
+            return Response::deny('まだフォローしていません。');
+        }
+
+        // その他の場合は認可
+        return Response::allow();
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,6 +3,9 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+use App\Models\User;
+use App\Policies\FollowPolicy;
+use App\Policies\UnfollowPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -13,7 +16,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        //
+        User::class => FollowPolicy::class,
     ];
 
     /**

--- a/app/UseCases/User/FollowAction.php
+++ b/app/UseCases/User/FollowAction.php
@@ -13,47 +13,30 @@ class FollowAction
     public function __invoke(Request $request, $userId)
     {
         $followUserId = Auth::id();
-        // 自分自身をフォローしようとしていないかをチェック
-        if ($followUserId !== (int)$userId) {
-            // フォローを作成
-            $follow = Follow::create([
-                'following_user_id' => $followUserId,
-                'followed_user_id' => $userId,
-            ]);
-            // フォロー数を取得
-            $followCount = Follow::where('following_user_id', $userId)->count();
-            // フォロワー数を取得
-            $followerCount = Follow::where('followed_user_id', $userId)->count();
 
-            // フォローを作成したユーザーを取得
-            $followedUser = User::find($userId);
-            // フォロー数とフォロワー数をユーザーモデルにセット
-            $followedUser->follow_count = $followCount;
-            $followedUser->follower_count = $followerCount;
+        // フォローを作成
+        $follow = Follow::create([
+            'following_user_id' => $followUserId,
+            'followed_user_id' => $userId,
+        ]);
 
-            // UserResourceに渡すデータに id、フォロー数、フォロワー数を含める
-            return new UserResource($followedUser);
-        }
+        // フォローを作成したユーザーを取得
+        $result = User::find($userId);
+
+        // フォロー数とフォロワー数を取得し、成功したかどうかを判定
+        $followCount = $result->followCount($userId);
+        $followerCount = $result->followerCount($userId);
+
+        // フォロー数とフォロワー数をユーザーモデルにセット
+        $result->follow_count = $followCount;
+        $result->follower_count = $followerCount;
+
+        return $result;
     }
 }
-
-
 // めも
-// 自分がフォローすると、自分のフォロー数が増えて、相手のフォロワー数が増える
-// 相手からフォローされると、相手のフォロー数が増えて、自分のフォロワー数が増える
-
-// mysql> select * from follows;
-// +----+-------------------+------------------+------------+------------+
-// | id | following_user_id | followed_user_id | created_at | updated_at |
-// +----+-------------------+------------------+------------+------------+
-// |  1 |                 3 |                4 | NULL       | NULL       |
-// |  2 |                 1 |                3 | NULL       | NULL       |
-// +----+-------------------+------------------+------------+------------+
-// 2 rows in set (0.00 sec)
-
-
-// 1のユーザーfollowing_user_idは、3のユーザーfollowed_user_idをフォローしているので、フォロー数は1
-// 1のユーザーfollowed_user_idは、誰からもフォローされていないので、フォロワー数は0
-
-// 3のユーザーfollowing_user_idは、4のユーザーfollowed_user_idをフォローしているので、フォロー数は1
-// 3のユーザーfollowed_user_idは、1のユーザーfollowing_user_idにフォローされているので、フォロワー数は1
+// if ($followUserId !== (int)$userId) {のif文は認可（ポリシー）？
+// ここはフォロー数の取得に成功したか失敗したかの判定だけにする。
+// 自分自身をフォローしていたらreturnしてしまう。スローで例外を返す。
+// /users/getのAPIでフォロー・フォロワー数の取得がnullになっちゃうので、Userモデルにfollow countとfollower countを入れる
+// return new UserResource($followedUser);はコントローラで返す。2重になっている。

--- a/app/UseCases/User/FollowAction.php
+++ b/app/UseCases/User/FollowAction.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\UseCases\User;
+
+use App\Models\User;
+use App\Models\Follow;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Http\Resources\UserResource;
+
+class FollowAction
+{
+    public function __invoke(Request $request, $userId)
+    {
+        $followUserId = Auth::id();
+        // 自分自身をフォローしようとしていないかをチェック
+        if ($followUserId !== (int)$userId) {
+            // フォローを作成
+            $follow = Follow::create([
+                'following_user_id' => $followUserId,
+                'followed_user_id' => $userId,
+            ]);
+            // フォロー数を取得
+            $followCount = Follow::where('following_user_id', $userId)->count();
+            // フォロワー数を取得
+            $followerCount = Follow::where('followed_user_id', $userId)->count();
+
+            // フォローを作成したユーザーを取得
+            $followedUser = User::find($userId);
+            // フォロー数とフォロワー数をユーザーモデルにセット
+            $followedUser->follow_count = $followCount;
+            $followedUser->follower_count = $followerCount;
+
+            // UserResourceに渡すデータに id、フォロー数、フォロワー数を含める
+            return new UserResource($followedUser);
+        }
+    }
+}
+
+
+// めも
+// 自分がフォローすると、自分のフォロー数が増えて、相手のフォロワー数が増える
+// 相手からフォローされると、相手のフォロー数が増えて、自分のフォロワー数が増える
+
+// mysql> select * from follows;
+// +----+-------------------+------------------+------------+------------+
+// | id | following_user_id | followed_user_id | created_at | updated_at |
+// +----+-------------------+------------------+------------+------------+
+// |  1 |                 3 |                4 | NULL       | NULL       |
+// |  2 |                 1 |                3 | NULL       | NULL       |
+// +----+-------------------+------------------+------------+------------+
+// 2 rows in set (0.00 sec)
+
+
+// 1のユーザーfollowing_user_idは、3のユーザーfollowed_user_idをフォローしているので、フォロー数は1
+// 1のユーザーfollowed_user_idは、誰からもフォローされていないので、フォロワー数は0
+
+// 3のユーザーfollowing_user_idは、4のユーザーfollowed_user_idをフォローしているので、フォロー数は1
+// 3のユーザーfollowed_user_idは、1のユーザーfollowing_user_idにフォローされているので、フォロワー数は1

--- a/app/UseCases/User/ShowAction.php
+++ b/app/UseCases/User/ShowAction.php
@@ -11,11 +11,19 @@ class ShowAction
 {
     public function __invoke($userId)
     {
-        $user = User::findOrFail($userId);
-
         try {
+            $user = User::findOrFail($userId);
+
+            // フォロー数とフォロワー数を取得
+            $followCount = $user->followCount($userId);
+            $followerCount = $user->followerCount($userId);
+
+            // フォロー数とフォロワー数をユーザーモデルにセット
+            $user->follow_count = $followCount;
+            $user->follower_count = $followerCount;
+
             return $user;
-        
+
         } catch (ModelNotFoundException $e) {
             // データが見つからなかっただけならロギング不要
             throw $e;

--- a/app/UseCases/User/UnfollowAction.php
+++ b/app/UseCases/User/UnfollowAction.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\UseCases\User;
+
+use App\Models\User;
+use App\Models\Follow;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Http\Resources\UserResource;
+
+class UnfollowAction
+{
+    public function __invoke(Request $request, $userId)
+    {
+        $followUserId = Auth::id();
+        // 自分自身をフォローしようとしていないかをチェック
+        if ($followUserId !== (int)$userId) {
+            // フォローを作成
+            $follow = Follow::where([
+                'following_user_id' => $followUserId,
+                'followed_user_id' => $userId,
+            ])->delete();
+        
+            // フォロー数を取得
+            $followCount = Follow::where('following_user_id', $userId)->count();
+
+            // フォロワー数を取得
+            $followerCount = Follow::where('followed_user_id', $userId)->count();
+
+            // フォローを作成したユーザーを取得
+            $followedUser = User::find($userId);
+            // フォロー数とフォロワー数をユーザーモデルにセット
+            $followedUser->follow_count = $followCount;
+            $followedUser->follower_count = $followerCount;
+
+            // UserResourceに渡すデータに id、フォロー数、フォロワー数を含める
+            return new UserResource($followedUser);
+        }
+    }
+}

--- a/app/UseCases/User/UnfollowAction.php
+++ b/app/UseCases/User/UnfollowAction.php
@@ -13,28 +13,24 @@ class UnfollowAction
     public function __invoke(Request $request, $userId)
     {
         $followUserId = Auth::id();
-        // 自分自身をフォローしようとしていないかをチェック
-        if ($followUserId !== (int)$userId) {
-            // フォローを作成
-            $follow = Follow::where([
-                'following_user_id' => $followUserId,
-                'followed_user_id' => $userId,
-            ])->delete();
-        
-            // フォロー数を取得
-            $followCount = Follow::where('following_user_id', $userId)->count();
 
-            // フォロワー数を取得
-            $followerCount = Follow::where('followed_user_id', $userId)->count();
+        // フォローを解除
+        $follow = Follow::where([
+            'following_user_id' => $followUserId,
+            'followed_user_id' => $userId,
+        ])->delete();
 
-            // フォローを作成したユーザーを取得
-            $followedUser = User::find($userId);
-            // フォロー数とフォロワー数をユーザーモデルにセット
-            $followedUser->follow_count = $followCount;
-            $followedUser->follower_count = $followerCount;
+        // フォローを作成したユーザーを取得
+        $result = User::find($userId);
 
-            // UserResourceに渡すデータに id、フォロー数、フォロワー数を含める
-            return new UserResource($followedUser);
-        }
+        // フォロー数とフォロワー数を取得し、成功したかどうかを判定
+        $followCount = $result->followCount($userId);
+        $followerCount = $result->followerCount($userId);
+
+        // フォロー数とフォロワー数をユーザーモデルにセット
+        $result->follow_count = $followCount;
+        $result->follower_count = $followerCount;
+
+        return $result;
     }
 }

--- a/database/migrations/2024_03_16_234321_add_unique_constraint_to_follows_table.php
+++ b/database/migrations/2024_03_16_234321_add_unique_constraint_to_follows_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('follows', function (Blueprint $table) {
+            // ユニーク制約を追加する
+            $table->unique(['following_user_id', 'followed_user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('follows', function (Blueprint $table) {
+            // ユニーク制約を削除する
+            $table->dropUnique(['following_user_id', 'followed_user_id']);
+        });
+    }
+};

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -166,7 +166,7 @@ paths:
         - user
       operationId: FollowUser
       parameters:
-        - name: userId
+        - name: userId           # フォローする相手のuserId（followed_user_id）
           in: path
           required: true
           schema:
@@ -188,7 +188,7 @@ paths:
         - user
       operationId: UnfollowUser
       parameters:
-        - name: userId
+        - name: userId           # フォローする相手のuserId（followed_user_id）
           in: path
           required: true
           schema:
@@ -430,9 +430,9 @@ components:
           type: string
         iconAttachment:
           $ref: '#/components/schemas/Attachment'
-        follow_count:
+        follow_count:           # フォロー数（following_user_id）
           type: integer
-        follower_count: 
+        follower_count:           # フォロワー数（followed_user_id）
           type: integer
         deletedAt:
           type: string

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -196,6 +196,12 @@ paths:
       responses:
         '200':
           description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
       security:
         - bearerAuth: []         # use the same name as above
   /posts:


### PR DESCRIPTION
実装内容
/users/{userId}/follow /users/{userId}/unfollow
フォローする・フォロー解除機能、フォロー数・フォロワー数のカウント処理

詳細は以下の通りです。 
・openapi.yamlのフォロー機能のAPI定義修正（/users/{userId}/unfollowのレスポンスがJSON形式で帰ってこなかったので修正）
・「UserController.php」の「follow()」メソッド・「unfollow()」メソッドに認可を追加
・「AuthServiceProvider.php」にポリシー「FollowPolicy
」を設定
・「FollowPolicy.php」で認可のまとめ
・「User.php」に「followCount()」メソッド、「followerCount()」メソッドを追加
・「ShowAction.php」のtry句修正、フォロー数とフォロワー数を取得処理で/users/{userId}のレスポンスで返ってくるように修正
・「FollowAction.php」「UnfollowAction.php」でフォロー機能の修正

疑問点
「FollowAction.php」「UnfollowAction.php」のフォロー数・フォロワー数の取得に成功したかどうか判定する件についてヒントをください。

if文で判定式を書いて例外をスローする感じのイメージだったのですが、Userモデルに入れた「followCount()」メソッド、「followerCount()」メソッドを呼び出すのは取得になりますか？
まずフォロー数・フォロワー数が取得できないと成功したかどうか判定できないのではないかと思います。

以上です。