### PR TITLE
/posts/{postId}の実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,12 +2,15 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Post;
 use Illuminate\Http\Request;
 use App\UseCases\Post\IndexAction;
 use App\UseCases\Post\CreateAction;
+use App\UseCases\Post\UpdateAction;
 use App\Http\Resources\PostResource;
 use App\Http\Requests\Post\IndexRequest;
 use App\Http\Requests\Post\CreateRequest;
+use App\Http\Requests\Post\UpdateRequest;
 
 class PostController extends Controller
 {
@@ -21,6 +24,13 @@ class PostController extends Controller
     public function create(CreateRequest $request, CreateAction $createAction)
     {
         $post = $createAction($request);
+        return new PostResource($post);
+    }
+
+    public function update(UpdateRequest $request, UpdateAction $updateAction, $postId)
+    {
+        $this->authorize('update', Post::findOrFail($postId));
+        $post = $updateAction($request, $postId);
         return new PostResource($post);
     }
 }

--- a/app/Http/Requests/Post/UpdateRequest.php
+++ b/app/Http/Requests/Post/UpdateRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Post;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'content' => 'required|string|max:255',
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'content.required' => 'つぶやき投稿は必須項目です。',
+            'content.string' => 'つぶやき投稿は文字列で入力してください',
+            'content.max' => 'つぶやき投稿は最大文字数255文字以内で入力してください。'
+        ];
+    }
+}

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class PostPolicy
+{
+    /**
+     * Create a new policy instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    public function update(User $user, Post $post)
+    {
+        // 自分の投稿を更新しようとしている場合は認可
+        if ($user->id === $post->user_id) {
+            return Response::allow();
+        }
+
+        // 他人の投稿を更新しようとしている場合は拒否
+        return Response::deny('他人の投稿を更新することはできません。');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,8 +4,8 @@ namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
 use App\Models\User;
+use App\Policies\PostPolicy;
 use App\Policies\FollowPolicy;
-use App\Policies\UnfollowPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -17,6 +17,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         User::class => FollowPolicy::class,
+        User::class => PostPolicy::class,
     ];
 
     /**

--- a/app/UseCases/Post/UpdateAction.php
+++ b/app/UseCases/Post/UpdateAction.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\UseCases\Post;
+
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class UpdateAction
+{
+    public function __invoke(Request $request, $postId)
+    {
+        $post = Post::findOrFail($postId);
+        $post->content = $request->input('content');
+        $post->attachment_id = $request->input('attachment_id');
+
+        $post->save();
+        return $post;
+    }
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -291,6 +291,8 @@ paths:
                 $ref: '#/components/schemas/Post'
         '404':
           description: Post not found
+      security:
+          - bearerAuth: []         # use the same name as above
   /posts/{postId}/replies:
     get:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,6 +27,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/posts', [PostController::class, 'index']); // つぶやき投稿一覧
     Route::post('/posts', [PostController::class, 'create']); // つぶやき投稿
 
+    Route::put('/posts/{postId}', [PostController::class, 'update']); // つぶやき更新
+
     Route::post('/users/{userId}/follow', [UserController::class, 'follow']); // フォロー
     Route::post('/users/{userId}/unfollow', [UserController::class, 'unfollow']); // フォロー解除
 });


### PR DESCRIPTION
実装内容
「/posts/{postId}」の実装

詳細は以下の通りです。
・openapi.yamlにBearerトークン追加
・「api.php」のルーティング追加
・「PostController.php」の「update()」メソッド追加
・「PostPolicy.php」で投稿のポリシーを実装
・「UpdateAction.php」で投稿の更新処理を実装
・「UpdateRequest.php」は「CreateRequest.php」と同じバリデーションルール

疑問点
他のユーザーが自分の投稿を更新することができてしまいます。PostController.phpでリクエストから渡された$postIdを取得し、ポリシーを作って他人が自分の投稿を更新できないようにしてみました。こんな感じでいいですか？

以上です。